### PR TITLE
chore: release v1.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.18.0](https://github.com/near/near-account-id/compare/v0.17.0...v0.18.0) - 2023-10-24
+
+### Added
+- Added `len` method ([#13](https://github.com/near/near-account-id/pull/13))
+
+### Other
+- renamed back remove_unchecked -> remove_unvalidated and hid behind a discouraging feature-flag ([#9](https://github.com/near/near-account-id/pull/9))
+- Add const AccountIdRef::new_or_panic ([#12](https://github.com/near/near-account-id/pull/12))
+- Upgrade borsh to 1.0 ([#8](https://github.com/near/near-account-id/pull/8))
+- Use stable Rust version for maximal-deps test ([#7](https://github.com/near/near-account-id/pull/7))
+- Added automated release pipeline (release-plz!)
+- Remove the `internal_unstable` feature flag
+- bump MSRV to 1.65
+- Merge pull request [#3](https://github.com/near/near-account-id/pull/3) from near/ci
+- make `impl Arbitrary for AccountId` DRYer
+- remove support for mutable AccountId refs
+- add missing serde/borsh implementations for `AccountIdRef`
+- convenience trait implementations for `AccountId`
+- add `AsMut` and `DerefMut` implementations
+- implement `Arbitrary` for `AccountIdRef`
+- more idiomatic AsRef/Borrow impls
+- move all methods to `AccountIdRef`
+- Introduce AccountIdRef
+- reorganize
+- typo
+- init

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.18.0](https://github.com/near/near-account-id/compare/v0.17.0...v0.18.0) - 2023-10-24
+## 1.0.0-alpha.1 - 2023-10-24
+
+near-account-id was extracted from [nearcore](https://github.com/near/nearcore) as of 2023-08-01, and extended with the following features to reach stable 1.0.0 release.
 
 ### Added
+- Introduce `AccountIdRef`, move all `AccountId` methods to `AccountIdRef`, and more idiomatic AsRef/Borrow impls
 - Added `len` method ([#13](https://github.com/near/near-account-id/pull/13))
+- Added const `AccountIdRef::new_or_panic` ([#12](https://github.com/near/near-account-id/pull/12))
+- Added missing serde/borsh implementations for `AccountIdRef`
+- Upgrade `borsh` dependency to 1.0 ([#8](https://github.com/near/near-account-id/pull/8))
+- Implemented `Arbitrary` for `AccountIdRef`
 
 ### Other
-- renamed back remove_unchecked -> remove_unvalidated and hid behind a discouraging feature-flag ([#9](https://github.com/near/near-account-id/pull/9))
-- Add const AccountIdRef::new_or_panic ([#12](https://github.com/near/near-account-id/pull/12))
-- Upgrade borsh to 1.0 ([#8](https://github.com/near/near-account-id/pull/8))
 - Use stable Rust version for maximal-deps test ([#7](https://github.com/near/near-account-id/pull/7))
 - Added automated release pipeline (release-plz!)
-- Remove the `internal_unstable` feature flag
 - bump MSRV to 1.65
-- Merge pull request [#3](https://github.com/near/near-account-id/pull/3) from near/ci
-- make `impl Arbitrary for AccountId` DRYer
-- remove support for mutable AccountId refs
-- add missing serde/borsh implementations for `AccountIdRef`
-- convenience trait implementations for `AccountId`
-- add `AsMut` and `DerefMut` implementations
-- implement `Arbitrary` for `AccountIdRef`
-- more idiomatic AsRef/Borrow impls
-- move all methods to `AccountIdRef`
-- Introduce AccountIdRef
-- reorganize
-- typo
-- init

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "0.18.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 description = "This crate contains the Account ID primitive and its validation facilities"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "0.18.0"
+version = "1.0.0-alpha.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 description = "This crate contains the Account ID primitive and its validation facilities"
@@ -10,6 +10,8 @@ publish = true
 
 [features]
 default = []
+# This feature was introduced for legacy reasons for nearcore, and MUST be avoided
+# https://github.com/near/nearcore/pull/4621#issuecomment-892099860
 internal_unstable = []
 
 [dependencies]


### PR DESCRIPTION
## 🤖 New release
* `near-account-id`: 0.17.0 -> 0.18.0 (⚠️ API breaking changes)

### ⚠️ `near-account-id` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.0/src/lints/inherent_method_missing.ron

Failed in:
  AccountId::as_str, previously in file /tmp/.tmpM0xFjI/near-account-id/src/lib.rs:83
  AccountId::is_top_level, previously in file /tmp/.tmpM0xFjI/near-account-id/src/lib.rs:103
  AccountId::is_sub_account_of, previously in file /tmp/.tmpM0xFjI/near-account-id/src/lib.rs:129
  AccountId::is_implicit, previously in file /tmp/.tmpM0xFjI/near-account-id/src/lib.rs:152
  AccountId::is_system, previously in file /tmp/.tmpM0xFjI/near-account-id/src/lib.rs:171
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.18.0](https://github.com/near/near-account-id/compare/v0.17.0...v0.18.0) - 2023-10-24

### Added
- Added `len` method ([#13](https://github.com/near/near-account-id/pull/13))

### Other
- renamed back remove_unchecked -> remove_unvalidated and hid behind a discouraging feature-flag ([#9](https://github.com/near/near-account-id/pull/9))
- Add const AccountIdRef::new_or_panic ([#12](https://github.com/near/near-account-id/pull/12))
- Upgrade borsh to 1.0 ([#8](https://github.com/near/near-account-id/pull/8))
- Use stable Rust version for maximal-deps test ([#7](https://github.com/near/near-account-id/pull/7))
- Added automated release pipeline (release-plz!)
- Remove the `internal_unstable` feature flag
- bump MSRV to 1.65
- Merge pull request [#3](https://github.com/near/near-account-id/pull/3) from near/ci
- make `impl Arbitrary for AccountId` DRYer
- remove support for mutable AccountId refs
- add missing serde/borsh implementations for `AccountIdRef`
- convenience trait implementations for `AccountId`
- add `AsMut` and `DerefMut` implementations
- implement `Arbitrary` for `AccountIdRef`
- more idiomatic AsRef/Borrow impls
- move all methods to `AccountIdRef`
- Introduce AccountIdRef
- reorganize
- typo
- init
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).