### PR TITLE
`AccountType`, add `EthImplicitAccount`

### DIFF
--- a/src/account_id_ref.rs
+++ b/src/account_id_ref.rs
@@ -49,8 +49,7 @@ impl AccountType {
     pub fn is_implicit(&self) -> bool {
         match &self {
             Self::NearImplicitAccount => true,
-            // TODO(eth-implicit) change to true later, see https://github.com/near/nearcore/issues/10018
-            Self::EthImplicitAccount => false,
+            Self::EthImplicitAccount => true,
             Self::NamedAccount => false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,5 +48,5 @@ mod test_data;
 mod validation;
 
 pub use account_id::AccountId;
-pub use account_id_ref::AccountIdRef;
+pub use account_id_ref::{AccountIdRef, AccountType};
 pub use errors::{ParseAccountError, ParseErrorKind};

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -93,6 +93,20 @@ pub fn validate(account_id: &str) -> Result<(), ParseAccountError> {
     }
 }
 
+pub fn is_eth_implicit(account_id: &str) -> bool {
+    account_id.len() == 42
+        && account_id.starts_with("0x")
+        && account_id[2..].as_bytes().iter().all(|b| matches!(b, b'a'..=b'f' | b'0'..=b'9'))
+}
+
+pub fn is_near_implicit(account_id: &str) -> bool {
+    account_id.len() == 64
+        && account_id
+            .as_bytes()
+            .iter()
+            .all(|b| matches!(b, b'a'..=b'f' | b'0'..=b'9'))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Part of https://github.com/near/nearcore/issues/10018.

This PR introduces some changes from https://github.com/near/nearcore/pull/9969 laying groundwork for real protocol changes to be done in a separate PR.

Summary:
- Add `AccountType` enum: `NamedAccount`, `NearImplicitAccount`, or `EthImplicitAccount`.
- Parse 40 characters long hexadecimal addresses prefixed with `'0x'` as `EthImplicitAccount`.
- For now, `AccountType::is_implicit()` returns false for `EthImplicitAccount`.