### PR TITLE
chore: release v1.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2](https://github.com/near/near-account-id-rs/compare/v1.0.0-alpha.1...v1.0.0-alpha.2) - 2023-11-03
+
+### Other
+- `AccountType`, add `EthImplicitAccount` ([#14](https://github.com/near/near-account-id-rs/pull/14))
+
 ## 1.0.0-alpha.1 - 2023-10-24
 
 near-account-id was extracted from [nearcore](https://github.com/near/nearcore) as of 2023-08-01, and extended with the following features to reach stable 1.0.0 release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 description = "This crate contains the Account ID primitive and its validation facilities"


### PR DESCRIPTION
## 🤖 New release
* `near-account-id`: 1.0.0-alpha.1 -> 1.0.0-alpha.2 (⚠️ API breaking changes)

### ⚠️ `near-account-id` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/inherent_method_missing.ron

Failed in:
  AccountIdRef::is_implicit, previously in file /tmp/.tmpEzh7Ck/near-account-id/src/account_id_ref.rs:160
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0-alpha.2](https://github.com/near/near-account-id-rs/compare/v1.0.0-alpha.1...v1.0.0-alpha.2) - 2023-11-03

### Other
- `AccountType`, add `EthImplicitAccount` ([#14](https://github.com/near/near-account-id-rs/pull/14))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).