### PR TITLE
chore: release v1.0.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.3](https://github.com/near/near-account-id-rs/compare/v1.0.0-alpha.2...v1.0.0-alpha.3) - 2023-11-06
+
+### Other
+- Add schemars support ([#17](https://github.com/near/near-account-id-rs/pull/17))
+
 ## [1.0.0-alpha.2](https://github.com/near/near-account-id-rs/compare/v1.0.0-alpha.1...v1.0.0-alpha.2) - 2023-11-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 description = "This crate contains the Account ID primitive and its validation facilities"


### PR DESCRIPTION
## 🤖 New release
* `near-account-id`: 1.0.0-alpha.2 -> 1.0.0-alpha.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0-alpha.3](https://github.com/near/near-account-id-rs/compare/v1.0.0-alpha.2...v1.0.0-alpha.3) - 2023-11-06

### Other
- Add schemars support ([#17](https://github.com/near/near-account-id-rs/pull/17))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).