### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.0.0 - 2023-12-22
+
+This is the first stable release of near-account-id crate!
+
+`AccountId` and `AccountIdRef` are two main types of this crate that have same relation as `String` and `str` in standard library of Rust.
+
+AccountId guarantees to hold a valid NEAR account id (unless users explicitly opt-in for the unvalidated constructors feature and break this promise).
+
+See all the changes listed in alpha releases below to learn about `AccountIdRef` and various new helper methods.
+
+### Added
+- Add `get_parent_account_id` method ([#24](https://github.com/near/near-account-id-rs/pull/24))
+
 ## [1.0.0-alpha.4](https://github.com/near/near-account-id-rs/compare/v1.0.0-alpha.3...v1.0.0-alpha.4) - 2023-11-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.0.0-alpha.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "1.0.0-alpha.4"
+version = "1.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 description = "This crate contains the Account ID primitive and its validation facilities"


### PR DESCRIPTION
## 🤖 New release
* `near-account-id`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0-alpha.5](https://github.com/near/near-account-id-rs/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) - 2023-12-21

### Added
- Add `get_parent_account_id` method ([#24](https://github.com/near/near-account-id-rs/pull/24))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).