### PR TITLE
remove an unnecessary optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ schemars-alpha = ["schemars", "dep:schemars-alpha"]
 
 [dependencies]
 arbitrary = {  version = "1", features = ["derive"] , optional = true }
-borsh = { version = "1.0.0", features = ["rc"], optional = true }
+borsh = { version = "1.0.0", optional = true }
 serde = { version = "1.0.119", features = ["alloc", "derive", "rc"], optional = true }
 schemars-stable = { version = "0.8.22", optional = true, package = "schemars" }
 schemars-alpha = { version = "1.0.0-alpha.17", optional = true, package = "schemars" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { version = ">=0.2.0, <0.5", features = ["arbitrary-derive"] }
-borsh = { version = "0.10", features = ["rc"] }
+borsh = { version = "0.10" }
 serde_json = "1.0.25"
 near-account-id = { path = ".." }
 


### PR DESCRIPTION
This crate is not using the `rc` feature of borsh.  Having it enabled here also enabled it on `nearcore`.  I am trying to disable it in `nearcore` as well.