### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/near/near-account-id-rs/compare/v1.1.1...v1.1.2) - 2025-07-03
+
+### Other
+
+- use toolchain 1.74 for release-plz ([#36](https://github.com/near/near-account-id-rs/pull/36))
+- The range of supported schemars versions is extended to >=0.8.22, <2 tu support the latest 1.0 release ([#34](https://github.com/near/near-account-id-rs/pull/34))
+
 ## [1.1.1](https://github.com/near/near-account-id-rs/compare/v1.1.0...v1.1.1) - 2025-05-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 description = "This crate contains the Account ID primitive and its validation facilities"


### PR DESCRIPTION



## 🤖 New release

* `near-account-id`: 1.1.1 -> 1.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.2](https://github.com/near/near-account-id-rs/compare/v1.1.1...v1.1.2) - 2025-07-03

### Other

- use toolchain 1.74 for release-plz ([#36](https://github.com/near/near-account-id-rs/pull/36))
- The range of supported schemars versions is extended to >=0.8.22, <2 tu support the latest 1.0 release ([#34](https://github.com/near/near-account-id-rs/pull/34))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).