### PR TITLE
chore: release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/near/near-account-id-rs/compare/v1.1.2...v1.1.3) - 2025-07-14
+
+### Other
+
+- Add schemars-v1 and schemars-v0_8 features, reverts schemars-stable to 0.8.22 ([#38](https://github.com/near/near-account-id-rs/pull/38))
+
 ## [1.1.2](https://github.com/near/near-account-id-rs/compare/v1.1.1...v1.1.2) - 2025-07-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 description = "This crate contains the Account ID primitive and its validation facilities"


### PR DESCRIPTION



## 🤖 New release

* `near-account-id`: 1.1.2 -> 1.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.3](https://github.com/near/near-account-id-rs/compare/v1.1.2...v1.1.3) - 2025-07-14

### Other

- Add schemars-v1 and schemars-v0_8 features, reverts schemars-stable to 0.8.22 ([#38](https://github.com/near/near-account-id-rs/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).