### PR TITLE
feat: NearDeterministicAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: New variant `NearDeterministicAccount` in `AccountType` as part of [NEP-616](https://github.com/near/NEPs/pull/616) implementation. (#42)
 
+### Changed
+
+- `AccountType::is_implicit()` will return `true` for the new account type `NearDeterministicAccount`. Callers should check their assumptions on what this method means.
+
 ## [1.1.4](https://github.com/near/near-account-id-rs/compare/v1.1.3...v1.1.4) - 2025-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- BREAKING: New variant `NearDeterministicAccount` in `AccountType` as part of [NEP-616](https://github.com/near/NEPs/pull/616) implementation. (#42)
+
+
 ## [1.1.4](https://github.com/near/near-account-id-rs/compare/v1.1.3...v1.1.4) - 2025-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: New variant `NearDeterministicAccount` in `AccountType` as part of [NEP-616](https://github.com/near/NEPs/pull/616) implementation. (#42)
 
-
 ## [1.1.4](https://github.com/near/near-account-id-rs/compare/v1.1.3...v1.1.4) - 2025-09-07
 
 ### Added

--- a/src/account_id_ref.rs
+++ b/src/account_id_ref.rs
@@ -207,8 +207,8 @@ impl AccountIdRef {
         if crate::validation::is_near_implicit(self.as_str()) {
             return AccountType::NearImplicitAccount;
         }
-        if crate::validation::is_deterministic_id_implicit(self.as_str()) {
-            return AccountType::NearImplicitAccount;
+        if crate::validation::is_near_deterministic(self.as_str()) {
+            return AccountType::NearDeterministicAccount;
         }
         AccountType::NamedAccount
     }

--- a/src/account_id_ref.rs
+++ b/src/account_id_ref.rs
@@ -43,6 +43,10 @@ pub enum AccountType {
     NearImplicitAccount,
     /// An account which address starts with '0x', followed by 40 hex characters.
     EthImplicitAccount,
+    /// An account which address starts with '0s', followed by 40 hex characters.
+    ///
+    /// See [NEP-616](https://github.com/near/NEPs/pull/616/) for more details.
+    NearDeterministicAccount,
 }
 
 impl AccountType {
@@ -50,6 +54,7 @@ impl AccountType {
         match &self {
             Self::NearImplicitAccount => true,
             Self::EthImplicitAccount => true,
+            Self::NearDeterministicAccount => true,
             Self::NamedAccount => false,
         }
     }
@@ -200,6 +205,9 @@ impl AccountIdRef {
             return AccountType::EthImplicitAccount;
         }
         if crate::validation::is_near_implicit(self.as_str()) {
+            return AccountType::NearImplicitAccount;
+        }
+        if crate::validation::is_deterministic_id_implicit(self.as_str()) {
             return AccountType::NearImplicitAccount;
         }
         AccountType::NamedAccount

--- a/src/account_id_ref.rs
+++ b/src/account_id_ref.rs
@@ -876,7 +876,6 @@ mod tests {
         }
     }
 
-
     #[test]
     #[cfg(feature = "arbitrary")]
     fn test_arbitrary() {

--- a/src/account_id_ref.rs
+++ b/src/account_id_ref.rs
@@ -835,6 +835,49 @@ mod tests {
     }
 
     #[test]
+    fn test_is_account_id_near_deterministic() {
+        let valid_near_deterministic_account_ids = &[
+            "0s0000000000000000000000000000000000000000",
+            "0s6174617461746174617461746174617461746174",
+            "0s0123456789abcdef0123456789abcdef01234567",
+            "0sffffffffffffffffffffffffffffffffffffffff",
+            "0s20782e20662e64666420482123494b6b6c677573",
+        ];
+        for valid_account_id in valid_near_deterministic_account_ids {
+            assert!(
+                matches!(
+                    valid_account_id.parse::<AccountId>(),
+                    Ok(account_id) if account_id.get_account_type() == AccountType::NearDeterministicAccount
+                ),
+                "Account ID {} should be valid 42-len hex, starting with 0s",
+                valid_account_id
+            );
+        }
+
+        let invalid_near_deterministic_account_ids = &[
+            "00s000000000000000000000000000000000000000",
+            "0s000000000000000000000000000000000000000",
+            "0s00000000000000000000000000000000000000.0",
+            "04b794f5ea0ba39494ce839613fffba74279579268",
+            "0x000000000000000000000000000000000000000",
+            "alice.near",
+            "0s.alice.near",
+            "0s.match_total_len_42_with_a_named_account",
+        ];
+        for invalid_account_id in invalid_near_deterministic_account_ids {
+            assert!(
+                !matches!(
+                    invalid_account_id.parse::<AccountId>(),
+                    Ok(account_id) if account_id.get_account_type() == AccountType::EthImplicitAccount
+                ),
+                "Account ID {} is not a NEAR deterministic account",
+                invalid_account_id
+            );
+        }
+    }
+
+
+    #[test]
     #[cfg(feature = "arbitrary")]
     fn test_arbitrary() {
         let corpus = [

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -102,7 +102,7 @@ pub fn is_eth_implicit(account_id: &str) -> bool {
             .all(|b| matches!(b, b'a'..=b'f' | b'0'..=b'9'))
 }
 
-pub fn is_deterministic_id_implicit(account_id: &str) -> bool {
+pub fn is_near_deterministic(account_id: &str) -> bool {
     account_id.len() == 42
         && account_id.starts_with("0s")
         && account_id[2..]

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -102,6 +102,15 @@ pub fn is_eth_implicit(account_id: &str) -> bool {
             .all(|b| matches!(b, b'a'..=b'f' | b'0'..=b'9'))
 }
 
+pub fn is_deterministic_id_implicit(account_id: &str) -> bool {
+    account_id.len() == 42
+        && account_id.starts_with("0s")
+        && account_id[2..]
+            .as_bytes()
+            .iter()
+            .all(|b| matches!(b, b'a'..=b'f' | b'0'..=b'9'))
+}
+
 pub fn is_near_implicit(account_id: &str) -> bool {
     account_id.len() == 64
         && account_id


### PR DESCRIPTION
Add a new kind of Near implicit account, which has the initial state and WASM code encoded in its id.

This is the main feature of NEP-616. https://github.com/near/NEPs/pull/616

I propose to keep the actual derivation of the id outside of this crate.
The derivation can live in near-primitives alongside other implicit id derivation functions.
See https://github.com/near/nearcore/blob/90c8b2504a8b2333082f4f937f3d581c2e4ec329/core/primitives/src/utils.rs#L446-L469.