### PR TITLE
chore: release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0](https://github.com/near/near-account-id-rs/compare/v2.5.0...v2.6.0) - 2026-03-17
+
+### Added
+
+- implement TryIntoAccountId for &String ([#59](https://github.com/near/near-account-id-rs/pull/59))
+
+### Other
+
+- upgrade to Rust edition 2024 ([#58](https://github.com/near/near-account-id-rs/pull/58))
+- migrate to org-wide NEARPROTOCOL_CI_PR_ACCESS token ([#57](https://github.com/near/near-account-id-rs/pull/57))
+- add DevEx to CODEOWNERS ([#55](https://github.com/near/near-account-id-rs/pull/55))
+
 ## [2.5.0](https://github.com/near/near-account-id-rs/compare/v2.4.0...v2.5.0) - 2025-12-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 description = "This crate contains the Account ID primitive and its validation facilities"


### PR DESCRIPTION



## 🤖 New release

* `near-account-id`: 2.5.0 -> 2.6.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.6.0](https://github.com/near/near-account-id-rs/compare/v2.5.0...v2.6.0) - 2026-03-17

### Added

- implement TryIntoAccountId for &String ([#59](https://github.com/near/near-account-id-rs/pull/59))

### Other

- upgrade to Rust edition 2024 ([#58](https://github.com/near/near-account-id-rs/pull/58))
- migrate to org-wide NEARPROTOCOL_CI_PR_ACCESS token ([#57](https://github.com/near/near-account-id-rs/pull/57))
- add DevEx to CODEOWNERS ([#55](https://github.com/near/near-account-id-rs/pull/55))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).