### PR TITLE
feat!: AccountType::UniversalAccount for 0u account IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- BREAKING: New variant `UniversalAccount` in `AccountType`, for the `0u` universal account IDs.
+
+### Changed
+
+- `AccountType::is_implicit()` will return `true` for the new account type `UniversalAccount`. Callers should check their assumptions on what this method means.
+
 ## [2.6.0](https://github.com/near/near-account-id-rs/compare/v2.5.0...v2.6.0) - 2026-03-17
 
 ### Added

--- a/src/account_id_ref.rs
+++ b/src/account_id_ref.rs
@@ -38,7 +38,7 @@ pub struct AccountIdRef(pub(crate) str);
 /// [`AccountIdRef`]: struct.AccountIdRef.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccountType {
-    /// Any valid account, that is neither NEAR-implicit nor ETH-implicit.
+    /// Any valid account that is not implicit.
     NamedAccount,
     /// An account with 64 characters long hexadecimal address.
     NearImplicitAccount,
@@ -48,6 +48,11 @@ pub enum AccountType {
     ///
     /// See [NEP-616](https://github.com/near/NEPs/pull/616/) for more details.
     NearDeterministicAccount,
+    /// An account which address starts with '0u', followed by 52 Crockford base32
+    /// characters encoding a 256-bit hash. Only the canonical encoding of a hash
+    /// counts, so an address whose trailing padding bits are set is a
+    /// [`NamedAccount`](AccountType::NamedAccount).
+    UniversalAccount,
 }
 
 impl AccountType {
@@ -56,6 +61,7 @@ impl AccountType {
             Self::NearImplicitAccount => true,
             Self::EthImplicitAccount => true,
             Self::NearDeterministicAccount => true,
+            Self::UniversalAccount => true,
             Self::NamedAccount => false,
         }
     }
@@ -214,9 +220,8 @@ impl AccountIdRef {
             .map_or(false, |s| !s.contains('.'))
     }
 
-    /// Returns `AccountType::EthImplicitAccount` if the `AccountId` is a 40 characters long hexadecimal prefixed with '0x'.
-    /// Returns `AccountType::NearImplicitAccount` if the `AccountId` is a 64 characters long hexadecimal.
-    /// Otherwise, returns `AccountType::NamedAccount`.
+    /// Returns the implicit account type whose address format the `AccountId` matches,
+    /// and `AccountType::NamedAccount` when it matches none of them.
     ///
     /// See [Implicit-Accounts](https://docs.near.org/docs/concepts/account#implicit-accounts).
     ///
@@ -247,6 +252,9 @@ impl AccountIdRef {
         }
         if crate::validation::is_near_deterministic(self.as_str()) {
             return AccountType::NearDeterministicAccount;
+        }
+        if crate::validation::is_universal(self.as_str()) {
+            return AccountType::UniversalAccount;
         }
         AccountType::NamedAccount
     }
@@ -926,6 +934,91 @@ mod tests {
                 ),
                 "Account ID {} is not a NEAR deterministic account",
                 invalid_account_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_account_id_universal() {
+        let valid_universal_account_ids = &[
+            "0u0000000000000000000000000000000000000000000000000000",
+            "0uzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzg",
+            "0u000g40r40m30e209185gr38e1w8124gk2gahc5rr34d1p70x3rfg",
+        ];
+        for valid_account_id in valid_universal_account_ids {
+            assert!(
+                matches!(
+                    valid_account_id.parse::<AccountId>(),
+                    Ok(account_id) if account_id.get_account_type() == AccountType::UniversalAccount
+                ),
+                "Account ID {} should be valid 54-len Crockford base32, starting with 0u",
+                valid_account_id
+            );
+        }
+
+        let invalid_universal_account_ids = &[
+            // Trailing padding bits set, so a second spelling of the all-zero hash.
+            "0u0000000000000000000000000000000000000000000000000001",
+            // `i` is not a Crockford symbol, though it is a valid account ID character.
+            "0u00000000000000000000000000000000000000000000000000i0",
+            "0u000000000000000000000000000000000000000000000000000",
+            "00u000000000000000000000000000000000000000000000000000",
+            "0s0000000000000000000000000000000000000000",
+            "0v0000000000000000000000000000000000000000000000000000",
+            "alice.near",
+            "0u.match_total_len_54_with_a_named_account_00000000000",
+        ];
+        for invalid_account_id in invalid_universal_account_ids {
+            assert!(
+                !matches!(
+                    invalid_account_id.parse::<AccountId>(),
+                    Ok(account_id) if account_id.get_account_type() == AccountType::UniversalAccount
+                ),
+                "Account ID {} is not a universal account",
+                invalid_account_id
+            );
+        }
+    }
+
+    /// The final symbol carries the four padding bits, so `0` and `g` are the only
+    /// values that leave them zero and the address canonical.
+    #[test]
+    fn test_universal_account_id_canonical_final_symbol() {
+        let crockford = "0123456789abcdefghjkmnpqrstvwxyz";
+        for final_symbol in crockford.chars() {
+            let account_id = format!("0u{}{}", "0".repeat(51), final_symbol);
+            let is_universal = matches!(
+                account_id.parse::<AccountId>(),
+                Ok(parsed) if parsed.get_account_type() == AccountType::UniversalAccount
+            );
+            assert_eq!(
+                is_universal,
+                final_symbol == '0' || final_symbol == 'g',
+                "final symbol {} classified as universal: {}",
+                final_symbol,
+                is_universal
+            );
+        }
+    }
+
+    /// Every generated address satisfies the predicate that defines the type.
+    #[test]
+    #[cfg(feature = "arbitrary")]
+    fn test_arbitrary_universal_account_id_is_universal() {
+        use crate::arbitrary::ArbitraryUniversalAccountId;
+        use arbitrary_with::UnstructuredExt;
+
+        let seeds = [[0x00u8; 52], [0xffu8; 52], [0x5au8; 52], [0x01u8; 52]];
+        for seed in seeds {
+            let mut u = arbitrary::Unstructured::new(&seed);
+            let account_id = u
+                .arbitrary_as::<AccountId, ArbitraryUniversalAccountId>()
+                .unwrap();
+            assert_eq!(
+                account_id.get_account_type(),
+                AccountType::UniversalAccount,
+                "generated {} is not a universal account",
+                account_id
             );
         }
     }

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -3,7 +3,11 @@ use core::iter;
 use arbitrary::{Arbitrary, Error, Result, Unstructured};
 use arbitrary_with::ArbitraryAs;
 
+use crate::validation::CROCKFORD;
 use crate::{AccountId, AccountIdRef, AccountType};
+
+/// Base32 symbols a universal account ID carries after its `0u` prefix.
+const NUM_UNIVERSAL_SYMBOLS: usize = 52;
 
 impl Arbitrary<'_> for AccountId {
     fn arbitrary(u: &mut Unstructured<'_>) -> Result<AccountId> {
@@ -12,6 +16,7 @@ impl Arbitrary<'_> for AccountId {
             AccountType::NearImplicitAccount,
             AccountType::EthImplicitAccount,
             AccountType::NearDeterministicAccount,
+            AccountType::UniversalAccount,
         ])? {
             AccountType::NamedAccount => {
                 // TLA
@@ -31,6 +36,7 @@ impl Arbitrary<'_> for AccountId {
             AccountType::NearDeterministicAccount => {
                 ArbitraryNearDeterministicAccountId::arbitrary_as(u)
             }
+            AccountType::UniversalAccount => ArbitraryUniversalAccountId::arbitrary_as(u),
         }
     }
 }
@@ -126,6 +132,47 @@ impl<'a> ArbitraryAs<'a, AccountId> for ArbitraryNearDeterministicAccountId {
     #[inline]
     fn size_hint_as(_depth: usize) -> (usize, Option<usize>) {
         (20, Some(20))
+    }
+}
+
+/// Adapter to generate arbitrary universal [`AccountId`] via [`ArbitraryAs`]:
+/// ```rust
+/// # use arbitrary::{Unstructured, Result};
+/// # use near_account_id::{
+/// #   AccountId, AccountType,
+/// #   arbitrary::ArbitraryUniversalAccountId,
+/// # };
+/// # fn main() -> Result<()> {
+/// # let mut u = Unstructured::new(&[]);
+/// use arbitrary_with::UnstructuredExt;
+///
+/// let account_id = u.arbitrary_as::<AccountId, ArbitraryUniversalAccountId>()?;
+/// assert_eq!(account_id.get_account_type(), AccountType::UniversalAccount);
+/// # Ok(())
+/// # }
+/// ```
+pub struct ArbitraryUniversalAccountId;
+impl<'a> ArbitraryAs<'a, AccountId> for ArbitraryUniversalAccountId {
+    #[inline]
+    fn arbitrary_as(u: &mut Unstructured<'a>) -> Result<AccountId> {
+        let bytes = u.arbitrary::<[u8; NUM_UNIVERSAL_SYMBOLS]>()?;
+        let (padding, body) = bytes.split_last().unwrap_or_else(|| unreachable!());
+
+        let mut account_id = String::with_capacity(2 + NUM_UNIVERSAL_SYMBOLS);
+        account_id.push_str("0u");
+        for &byte in body {
+            account_id.push(CROCKFORD[(byte % 32) as usize] as char);
+        }
+        // The last symbol carries the four padding bits, which a canonical address
+        // leaves zero, so `0` and `g` are the only values it can take.
+        account_id.push(if padding % 2 == 0 { '0' } else { 'g' });
+
+        Ok(account_id.parse().unwrap_or_else(|_| unreachable!()))
+    }
+
+    #[inline]
+    fn size_hint_as(_depth: usize) -> (usize, Option<usize>) {
+        (NUM_UNIVERSAL_SYMBOLS, Some(NUM_UNIVERSAL_SYMBOLS))
     }
 }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -111,6 +111,18 @@ pub fn is_near_deterministic(account_id: &str) -> bool {
             .all(|b| matches!(b, b'a'..=b'f' | b'0'..=b'9'))
 }
 
+/// Crockford base32, lowercase, excluding `i l o u` to reduce transcription errors.
+pub(crate) const CROCKFORD: &[u8; 32] = b"0123456789abcdefghjkmnpqrstvwxyz";
+
+pub fn is_universal(account_id: &str) -> bool {
+    account_id.len() == 54
+        && account_id.starts_with("0u")
+        && account_id[2..].as_bytes().iter().all(|b| CROCKFORD.contains(b))
+        // The hash is 256 bits and 52 symbols carry 260, so the last 4 bits are padding
+        // and must be zero for a canonical encoding: only `0` and `g` have zero there.
+        && matches!(account_id.as_bytes()[53], b'0' | b'g')
+}
+
 pub fn is_near_implicit(account_id: &str) -> bool {
     account_id.len() == 64
         && account_id


### PR DESCRIPTION
Adds `AccountType::UniversalAccount` for universal account IDs: `0u` plus 52 Crockford base32 symbols encoding a 256-bit hash. Callers can then match on the account type rather than testing the prefix themselves.

`AccountType` is not `#[non_exhaustive]`, so the variant breaks downstream exhaustive matches and release-plz will cut a 3.0.0, the same way `NearDeterministicAccount` did at 2.0.0. `is_implicit()` returns true for the new variant, and the changelog carries the same caller warning that release used.

The predicate is stricter than the `0x` and `0s` ones on purpose. Crockford omits `i l o u`, which are otherwise valid account ID characters, and the trailing four padding bits must be zero so that each hash has one address. Checking the last symbol is `0` or `g` covers those bits.

Possible follow-up: nearcore has its own `encode_universal_account_id` and `decode_universal_account_id`, which turn a hash into one of these addresses and back. Moving them into this crate would leave a single implementation, but that is a scope decision about what this crate owns, and adding public functions later is a minor release.
