### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.7.0](https://github.com/near/near-account-id-rs/compare/v2.6.0...v2.7.0) - 2026-08-28
+## [3.0.0](https://github.com/near/near-account-id-rs/compare/v2.6.0...v3.0.0) - 2026-08-28
 
 ### Added
 
-- AccountType::UniversalAccount for 0u account IDs ([#61](https://github.com/near/near-account-id-rs/pull/61))
-
-### Added
-
-- BREAKING: New variant `UniversalAccount` in `AccountType`, for the `0u` universal account IDs.
+- BREAKING: New variant `UniversalAccount` in `AccountType`, for the `0u` universal account IDs. ([#61](https://github.com/near/near-account-id-rs/pull/61))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0](https://github.com/near/near-account-id-rs/compare/v2.6.0...v2.7.0) - 2026-08-28
+
+### Added
+
+- AccountType::UniversalAccount for 0u account IDs ([#61](https://github.com/near/near-account-id-rs/pull/61))
+
 ### Added
 
 - BREAKING: New variant `UniversalAccount` in `AccountType`, for the `0u` universal account IDs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "2.7.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "2.7.0"
+version = "3.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 description = "This crate contains the Account ID primitive and its validation facilities"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-account-id"
-version = "2.6.0"
+version = "2.7.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 description = "This crate contains the Account ID primitive and its validation facilities"


### PR DESCRIPTION



## 🤖 New release

* `near-account-id`: 2.6.0 -> 3.0.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.0](https://github.com/near/near-account-id-rs/compare/v2.6.0...v3.0.0) - 2026-08-28

### Added

- BREAKING: New variant `UniversalAccount` in `AccountType`, for the `0u` universal account IDs. ([#61](https://github.com/near/near-account-id-rs/pull/61))

### Changed

- `AccountType::is_implicit()` will return `true` for the new account type `UniversalAccount`. Callers should check their assumptions on what this method means.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).